### PR TITLE
Add a REPL for inspecting how numbers get converted to LEB128

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,61 @@ assert_eq!(val, -12345);
 
 [Documentation](http://gimli-rs.github.io/leb128/leb128/index.html)
 
+## Read-Eval-Print-Loop for LEB128
+
+This crate comes with a `leb128-repl` program that you can use after `cargo
+install leb128` or by running `cargo run` in clone of this repository.
+
+```
+$ leb128-repl
+LEB128 Read-Eval-Print-Loop!
+
+Converts numbers to signed and unsigned LEB128 and displays the results in
+base-10, hex, and binary.
+
+> 42
+# unsigned LEB128
+[42]
+[2a]
+[00101010]
+
+# signed LEB128
+[42]
+[2a]
+[00101010]
+
+> -42
+# unsigned LEB128
+error
+
+# signed LEB128
+[86]
+[56]
+[01010110]
+
+> 9001
+# unsigned LEB128
+[169, 70]
+[a9, 46]
+[10101001, 01000110]
+
+# signed LEB128
+[169, 198, 0]
+[a9, c6, 0]
+[10101001, 11000110, 00000000]
+
+> -9001
+# unsigned LEB128
+error
+
+# signed LEB128
+[215, 185, 127]
+[d7, b9, 7f]
+[11010111, 10111001, 01111111]
+
+>
+```
+
 ## License
 
 Licensed under either of

--- a/src/bin/leb128-repl.rs
+++ b/src/bin/leb128-repl.rs
@@ -47,7 +47,7 @@ base-10, hex, and binary.
     let mut buf = vec![];
 
     loop {
-        stdout.write(b"> ").expect("failed to write to stdout");
+        stdout.write_all(b"> ").expect("failed to write to stdout");
         stdout.flush().expect("failed to flush stdout");
 
         buf.clear();
@@ -68,9 +68,9 @@ base-10, hex, and binary.
             })
             .unwrap_or_else(|| "error\n".into());
         stdout
-            .write(b"# unsigned LEB128\n")
-            .and_then(|_| stdout.write(uleb.as_bytes()))
-            .and_then(|_| stdout.write(b"\n"))
+            .write_all(b"# unsigned LEB128\n")
+            .and_then(|_| stdout.write_all(uleb.as_bytes()))
+            .and_then(|_| stdout.write_all(b"\n"))
             .expect("failed to write to stdout");
 
         let leb = str::from_utf8(&buf)
@@ -83,9 +83,9 @@ base-10, hex, and binary.
             })
             .unwrap_or_else(|| "error\n".into());
         stdout
-            .write(b"# signed LEB128\n")
-            .and_then(|_| stdout.write(leb.as_bytes()))
-            .and_then(|_| stdout.write(b"\n"))
+            .write_all(b"# signed LEB128\n")
+            .and_then(|_| stdout.write_all(leb.as_bytes()))
+            .and_then(|_| stdout.write_all(b"\n"))
             .expect("failed to write to stdout");
 
         stdout.flush().expect("failed to flush stdout");

--- a/src/bin/leb128-repl.rs
+++ b/src/bin/leb128-repl.rs
@@ -1,0 +1,93 @@
+extern crate leb128;
+
+use std::io::{self, BufRead, Write};
+use std::str;
+
+fn display(bytes: &[u8]) -> String {
+    let mut s = vec![];
+
+    // Base 10.
+    write!(&mut s, "{:?}\n", bytes).unwrap();
+
+    // Hex.
+    write!(&mut s, "[").unwrap();
+    for (i, b) in bytes.iter().enumerate() {
+        if i != 0 {
+            write!(&mut s, ", ").unwrap();
+        }
+        write!(&mut s, "{:0x}", b).unwrap();
+    }
+    writeln!(&mut s, "]").unwrap();
+
+    // Binary.
+    write!(&mut s, "[").unwrap();
+    for (i, b) in bytes.iter().enumerate() {
+        if i != 0 {
+            write!(&mut s, ", ").unwrap();
+        }
+        write!(&mut s, "{:08b}", b).unwrap();
+    }
+    writeln!(&mut s, "]").unwrap();
+
+    String::from_utf8(s).unwrap()
+}
+
+fn main() {
+    println!(
+        "
+LEB128 Read-Eval-Print-Loop!
+
+Converts numbers to signed and unsigned LEB128 and displays the results in
+base-10, hex, and binary.
+" );
+
+    let mut stdin = io::BufReader::new(io::stdin());
+    let mut stdout = io::stdout();
+
+    let mut buf = vec![];
+
+    loop {
+        stdout.write(b"> ").expect("failed to write to stdout");
+        stdout.flush().expect("failed to flush stdout");
+
+        buf.clear();
+        let n = stdin
+            .read_until(b'\n', &mut buf)
+            .expect("failed to read line from stdin");
+        if n == 0 {
+            break;
+        }
+
+        let uleb = str::from_utf8(&buf)
+            .ok()
+            .and_then(|s| s.trim().parse().ok())
+            .and_then(|n: u64| {
+                let mut s = vec![];
+                leb128::write::unsigned(&mut s, n).ok()?;
+                Some(display(&s))
+            })
+            .unwrap_or_else(|| "error\n".into());
+        stdout
+            .write(b"# unsigned LEB128\n")
+            .and_then(|_| stdout.write(uleb.as_bytes()))
+            .and_then(|_| stdout.write(b"\n"))
+            .expect("failed to write to stdout");
+
+        let leb = str::from_utf8(&buf)
+            .ok()
+            .and_then(|s| s.trim().parse().ok())
+            .and_then(|n: i64| {
+                let mut s = vec![];
+                leb128::write::signed(&mut s, n).ok()?;
+                Some(display(&s))
+            })
+            .unwrap_or_else(|| "error\n".into());
+        stdout
+            .write(b"# signed LEB128\n")
+            .and_then(|_| stdout.write(leb.as_bytes()))
+            .and_then(|_| stdout.write(b"\n"))
+            .expect("failed to write to stdout");
+
+        stdout.flush().expect("failed to flush stdout");
+    }
+}


### PR DESCRIPTION
I found this useful for trying to guage the impact of https://github.com/rust-lang-nursery/rust-wasm/issues/81#issuecomment-371617046 for example, and I imagine it would be useful for anyone working with LEB128 in general.