### PR TITLE
Overflow no longer leaves LEB128 values half-read 

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -115,6 +115,9 @@ pub mod read {
             r.read_exact(&mut buf)?;
 
             if shift == 63 && buf[0] != 0x00 && buf[0] != 0x01 {
+                while buf[0] & CONTINUATION_BIT != 0 {
+                    r.read_exact(&mut buf)?;
+                }
                 return Err(Error::Overflow);
             }
 
@@ -147,6 +150,9 @@ pub mod read {
 
             byte = buf[0];
             if shift == 63 && byte != 0x00 && byte != 0x7f {
+                while buf[0] & CONTINUATION_BIT != 0 {
+                    r.read_exact(&mut buf)?;
+                }
                 return Err(Error::Overflow);
             }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -552,4 +552,27 @@ mod tests {
             1u64
         );
     }
+
+    #[test]
+    fn test_read_multiple_with_overflow() {
+        let buf = [
+            0b1111_1111, 0b1111_1111, 0b1111_1111, 0b1111_1111,
+            0b1111_1111, 0b1111_1111, 0b1111_1111, 0b1111_1111,
+            0b1111_1111, 0b1111_1111, 0b0111_1111, // Overflow!
+            0b1110_0100, 0b1110_0000, 0b0000_0010, // 45156
+        ];
+        let mut readable = &buf[..];
+
+        assert!(
+            if let read::Error::Overflow = read::unsigned(&mut readable).expect_err("Should fail with Error::Overflow") {
+                true
+            } else {
+                false
+            }
+        );
+        assert_eq!(
+            read::unsigned(&mut readable).expect("Should succeed with correct value"),
+            45156
+        );
+    }
 }


### PR DESCRIPTION
Fixes #14