### PR TITLE
Allow dyn traits to be used with io::Read

### DIFF
--- a/src/bin/leb128-repl.rs
+++ b/src/bin/leb128-repl.rs
@@ -39,7 +39,8 @@ LEB128 Read-Eval-Print-Loop!
 
 Converts numbers to signed and unsigned LEB128 and displays the results in
 base-10, hex, and binary.
-" );
+"
+    );
 
     let mut stdin = io::BufReader::new(io::stdin());
     let mut stdout = io::stdout();


### PR DESCRIPTION
Add a ?Sized constraint to read::signed and read::unsigned, allowing dyn
traits to be used with those functions. This also makes them consistent
with the write functions, which already impose that constraint.

Apparently, cargo fmt also restyled some code.