### PR TITLE
WIP no_std support

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,8 @@
 [package]
-authors = ["Nick Fitzgerald <fitzgen@gmail.com>", "Philip Craig <philipjcraig@gmail.com>"]
+authors = [
+    "Nick Fitzgerald <fitzgen@gmail.com>",
+    "Philip Craig <philipjcraig@gmail.com>",
+]
 name = "leb128"
 version = "0.2.5"
 edition = "2018"
@@ -14,9 +17,12 @@ repository = "https://github.com/gimli-rs/leb128"
 exclude = ["/.travis.yml", "/.coveralls.yml", "/format"]
 
 [dependencies]
+embedded-io = "0.6.1"
 
 [dev-dependencies]
 quickcheck = "0.8.0"
 
 [features]
 nightly = []
+default = ["std"]
+std = ["embedded-io/std"]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -330,20 +330,20 @@ mod tests {
         );
     }
 
-    #[test]
-    fn test_read_unsigned_thru_dyn_trait() {
-        fn read(r: &mut dyn io::Read) -> u64 {
-            read::unsigned(r).expect("Should read number")
-        }
+    // #[test]
+    // fn test_read_unsigned_thru_dyn_trait() {
+    //     fn read(r: &mut dyn io::Read) -> u64 {
+    //         read::unsigned(r).expect("Should read number")
+    //     }
 
-        let buf = [0u8];
+    //     let buf = [0u8];
 
-        let mut readable = &buf[..];
-        assert_eq!(0, read(&mut readable));
+    //     let mut readable = &buf[..];
+    //     assert_eq!(0, read(&mut readable));
 
-        let mut readable = io::Cursor::new(buf);
-        assert_eq!(0, read(&mut readable));
-    }
+    //     let mut readable = io::Cursor::new(buf);
+    //     assert_eq!(0, read(&mut readable));
+    // }
 
     // Examples from the DWARF 4 standard, section 7.6, figure 23.
     #[test]
@@ -399,20 +399,20 @@ mod tests {
         );
     }
 
-    #[test]
-    fn test_read_signed_thru_dyn_trait() {
-        fn read(r: &mut dyn io::Read) -> i64 {
-            read::signed(r).expect("Should read number")
-        }
+    // #[test]
+    // fn test_read_signed_thru_dyn_trait() {
+    //     fn read(r: &mut dyn io::Read) -> i64 {
+    //         read::signed(r).expect("Should read number")
+    //     }
 
-        let buf = [0u8];
+    //     let buf = [0u8];
 
-        let mut readable = &buf[..];
-        assert_eq!(0, read(&mut readable));
+    //     let mut readable = &buf[..];
+    //     assert_eq!(0, read(&mut readable));
 
-        let mut readable = io::Cursor::new(buf);
-        assert_eq!(0, read(&mut readable));
-    }
+    //     let mut readable = io::Cursor::new(buf);
+    //     assert_eq!(0, read(&mut readable));
+    // }
 
     #[test]
     fn test_read_signed_63_bits() {
@@ -438,73 +438,73 @@ mod tests {
     fn test_read_unsigned_not_enough_data() {
         let buf = [CONTINUATION_BIT];
         let mut readable = &buf[..];
-        match read::unsigned(&mut readable) {
-            Err(read::Error::IoError(e)) => assert_eq!(e.kind(), io::ErrorKind::UnexpectedEof),
-            otherwise => panic!("Unexpected: {:?}", otherwise),
-        }
+        assert!(matches!(
+            read::unsigned(&mut readable),
+            Err(read::Error::UnexpectedEof)
+        ));
     }
 
     #[test]
     fn test_read_signed_not_enough_data() {
         let buf = [CONTINUATION_BIT];
         let mut readable = &buf[..];
-        match read::signed(&mut readable) {
-            Err(read::Error::IoError(e)) => assert_eq!(e.kind(), io::ErrorKind::UnexpectedEof),
-            otherwise => panic!("Unexpected: {:?}", otherwise),
-        }
+        assert!(matches!(
+            read::signed(&mut readable),
+            Err(read::Error::UnexpectedEof)
+        ));
     }
 
     #[test]
     fn test_write_unsigned_not_enough_space() {
         let mut buf = [0; 1];
         let mut writable = &mut buf[..];
-        match write::unsigned(&mut writable, 128) {
-            Err(e) => assert_eq!(e.kind(), io::ErrorKind::WriteZero),
-            otherwise => panic!("Unexpected: {:?}", otherwise),
-        }
+        assert!(matches!(
+            write::unsigned(&mut writable, 128),
+            Err(embedded_io::SliceWriteError::Full)
+        ));
     }
 
     #[test]
     fn test_write_signed_not_enough_space() {
         let mut buf = [0; 1];
         let mut writable = &mut buf[..];
-        match write::signed(&mut writable, 128) {
-            Err(e) => assert_eq!(e.kind(), io::ErrorKind::WriteZero),
-            otherwise => panic!("Unexpected: {:?}", otherwise),
-        }
+        assert!(matches!(
+            write::signed(&mut writable, 128),
+            Err(embedded_io::SliceWriteError::Full)
+        ));
     }
 
-    #[test]
-    fn test_write_unsigned_thru_dyn_trait() {
-        fn write(w: &mut dyn io::Write, val: u64) -> usize {
-            write::unsigned(w, val).expect("Should write number")
-        }
-        let mut buf = [0u8; 1];
+    // #[test]
+    // fn test_write_unsigned_thru_dyn_trait() {
+    //     fn write(w: &mut dyn io::Write, val: u64) -> usize {
+    //         write::unsigned(w, val).expect("Should write number")
+    //     }
+    //     let mut buf = [0u8; 1];
 
-        let mut writable = &mut buf[..];
-        assert_eq!(write(&mut writable, 0), 1);
-        assert_eq!(buf[0], 0);
+    //     let mut writable = &mut buf[..];
+    //     assert_eq!(write(&mut writable, 0), 1);
+    //     assert_eq!(buf[0], 0);
 
-        let mut writable = Vec::from(&buf[..]);
-        assert_eq!(write(&mut writable, 0), 1);
-        assert_eq!(buf[0], 0);
-    }
+    //     let mut writable = Vec::from(&buf[..]);
+    //     assert_eq!(write(&mut writable, 0), 1);
+    //     assert_eq!(buf[0], 0);
+    // }
 
-    #[test]
-    fn test_write_signed_thru_dyn_trait() {
-        fn write(w: &mut dyn io::Write, val: i64) -> usize {
-            write::signed(w, val).expect("Should write number")
-        }
-        let mut buf = [0u8; 1];
+    // #[test]
+    // fn test_write_signed_thru_dyn_trait() {
+    //     fn write(w: &mut dyn io::Write, val: i64) -> usize {
+    //         write::signed(w, val).expect("Should write number")
+    //     }
+    //     let mut buf = [0u8; 1];
 
-        let mut writable = &mut buf[..];
-        assert_eq!(write(&mut writable, 0), 1);
-        assert_eq!(buf[0], 0);
+    //     let mut writable = &mut buf[..];
+    //     assert_eq!(write(&mut writable, 0), 1);
+    //     assert_eq!(buf[0], 0);
 
-        let mut writable = Vec::from(&buf[..]);
-        assert_eq!(write(&mut writable, 0), 1);
-        assert_eq!(buf[0], 0);
-    }
+    //     let mut writable = Vec::from(&buf[..]);
+    //     assert_eq!(write(&mut writable, 0), 1);
+    //     assert_eq!(buf[0], 0);
+    // }
 
     #[test]
     fn dogfood_signed() {

--- a/tests/quickchecks.rs
+++ b/tests/quickchecks.rs
@@ -1,13 +1,11 @@
-use leb128;
-use quickcheck;
-
+use std::convert::Infallible;
 use std::io;
 
 #[test]
 fn can_write_any_unsigned_int() {
     fn f(x: u64) -> io::Result<()> {
         let mut v = vec![];
-        leb128::write::unsigned(&mut v, x)?;
+        never_fails(leb128::write::unsigned(&mut v, x));
         Ok(())
     }
     quickcheck::quickcheck(f as fn(u64) -> io::Result<()>);
@@ -15,21 +13,20 @@ fn can_write_any_unsigned_int() {
 
 #[test]
 fn can_round_trip_any_unsigned_int() {
-    fn f(x: u64) -> io::Result<bool> {
+    fn f(x: u64) -> bool {
         let mut v = vec![];
-        leb128::write::unsigned(&mut v, x)?;
-        let y = leb128::read::unsigned(&mut &v[..])
-            .map_err(|e| io::Error::new(io::ErrorKind::Other, e))?;
-        Ok(x == y)
+        never_fails(leb128::write::unsigned(&mut v, x));
+        let y = never_fails2(leb128::read::unsigned(&mut &v[..]));
+        x == y
     }
-    quickcheck::quickcheck(f as fn(u64) -> io::Result<bool>);
+    quickcheck::quickcheck(f as fn(u64) -> bool);
 }
 
 #[test]
 fn can_write_any_signed_int() {
     fn f(x: i64) -> io::Result<()> {
         let mut v = vec![];
-        leb128::write::signed(&mut v, x)?;
+        never_fails(leb128::write::signed(&mut v, x));
         Ok(())
     }
     quickcheck::quickcheck(f as fn(i64) -> io::Result<()>);
@@ -39,10 +36,17 @@ fn can_write_any_signed_int() {
 fn can_round_trip_any_signed_int() {
     fn f(x: i64) -> io::Result<bool> {
         let mut v = vec![];
-        leb128::write::signed(&mut v, x)?;
-        let y = leb128::read::signed(&mut &v[..])
-            .map_err(|e| io::Error::new(io::ErrorKind::Other, e))?;
+        never_fails(leb128::write::signed(&mut v, x));
+        let y = never_fails2(leb128::read::signed(&mut &v[..]));
         Ok(x == y)
     }
     quickcheck::quickcheck(f as fn(i64) -> io::Result<bool>);
+}
+
+fn never_fails<T>(r: Result<T, Infallible>) -> T {
+    r.unwrap()
+}
+
+fn never_fails2<T>(r: Result<T, leb128::read::Error<std::convert::Infallible>>) -> T {
+    r.unwrap()
 }


### PR DESCRIPTION
This is a draft of no_std support implementation. Closes #25. 

TODO:

* [] `std::error::Error` implementation for `Error`.
* [] Fix `test_*_thru_dyn_trait` tests. Either make them accept `embedded_io::Read` or find a way to make the functions work with std::io::Read.

A nice bonus is that now quite a few code examples using built-in collections are statically proven to be Infallible.